### PR TITLE
docs: add installation instructions for PostgreSQL on Ubuntu to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,5 @@ GRANT ALL PRIVILEGES ON DATABASE myapp_development TO myappuser;
 Lastly in config/database.yml be sure to set the username, password, and database fields to match the PostgreSQL configuration you set up.
 
 #### Windows
+
+You can install PostgreSQL using WSL and following the above guide for Ubuntu.

--- a/README.md
+++ b/README.md
@@ -40,4 +40,39 @@ brew link postgresql@15
 brew services start postgresql@15
 ```
 
+#### Ubuntu
+
+One way to install PostgreSQL on Ubuntu is via apt
+
+```shell
+sudo apt update
+sudo apt install postgresql postgresql-contrib
+```
+
+To start running the PostgreSQL Service:
+```shell
+sudo service postgresql start
+# If you want to enable it to always start at boot
+sudo systemctl enable postgresql
+```
+
+To access PostgreSQL via the postgres user and then enter PostgreSQL prompt
+```shell
+sudo -i -u postgres
+psql
+# To exit PostgreSQL prompt run
+# \q
+```
+
+To create a PostgreSQL User and Database for development (replace myapp_development, myappuser, and 'password' with the desired names for your database, user, and password).
+```shell
+CREATE DATABASE myapp_development;
+CREATE USER myappuser WITH PASSWORD 'password';
+ALTER ROLE myappuser SET client_encoding TO 'utf8';
+ALTER ROLE myappuser SET default_transaction_isolation TO 'read committed';
+ALTER ROLE myappuser SET timezone TO 'UTC';
+GRANT ALL PRIVILEGES ON DATABASE myapp_development TO myappuser;
+```
+Lastly in config/database.yml be sure to set the username, password, and database fields to match the PostgreSQL configuration you set up.
+
 #### Windows


### PR DESCRIPTION
Added detailed instructions on how to install and configure PostgreSQL on Ubuntu in the README file.

This worked for me on WSL running Ubuntu 20.04.