### PR TITLE
fix: make Bootstrap work properly

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,10 +10,11 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
- *= require_self
- *= require rails_bootstrap_forms
  */
+
+@import "bootstrap";
+@import "rails_bootstrap_forms";
+
 .flash-notice {
     background-color: #4CAF50;
     color: #fff;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,8 @@
         <%= flash[:alert] %>
       </div>
     <% end %>
-    <%= yield %>
+    <div class="container">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,2 @@
+pin "bootstrap", to: "bootstrap.min.js", preload: true
+pin "@popperjs/core", to: "popper.js", preload: true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,3 +10,5 @@ Rails.application.config.assets.version = "1.0"
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+Rails.application.config.assets.precompile += %w[(bootstrap.min.js popper.js]


### PR DESCRIPTION
Before, Bootstrap wasn't properly styling elements (like in forms). This fixes it by following the [setup instructions](https://github.com/twbs/bootstrap-rubygem#a-ruby-on-rails) for Rails. 