### PR TITLE
fix: problem with email top level domains

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   before_save :create_session_token
   validates :first_name, presence: true, length: {maximum: 50}
   validates :last_name, presence: true, length: {maximum: 50}
-  VALID_EMAIL_REGEX = /\A(|(([A-Za-z0-9]+_+)|([A-Za-z0-9]+-+)|([A-Za-z0-9]+\.+)|([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+-+)|(\w+\.))*\w{1,63}\.[a-zA-Z]{2,6})\z/i
+  VALID_EMAIL_REGEX = /\A(|(([A-Za-z0-9]+_+)|([A-Za-z0-9]+-+)|([A-Za-z0-9]+\.+)|([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+-+)|(\w+\.))*\w{1,63}\.[a-zA-Z]{2,63})\z/i
   validates :email, presence: true,
     format: {with: VALID_EMAIL_REGEX},
     uniqueness: {case_sensitive: false}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   before_save :create_session_token
   validates :first_name, presence: true, length: {maximum: 50}
   validates :last_name, presence: true, length: {maximum: 50}
-  VALID_EMAIL_REGEX = /\A(|(([A-Za-z0-9]+_+)|([A-Za-z0-9]+-+)|([A-Za-z0-9]+\.+)|([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+-+)|(\w+\.))*\w{1,63}\.[a-zA-Z]{2,63})\z/i
+  VALID_EMAIL_REGEX = /\A(|(([A-Za-z0-9]+_+)|([A-Za-z0-9]+-+)|([A-Za-z0-9]+\.+)|([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+-+)|(\w+\.))*\w{1,63}\.[a-zA-Z]{2,24})\z/i
   validates :email, presence: true,
     format: {with: VALID_EMAIL_REGEX},
     uniqueness: {case_sensitive: false}

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -18,7 +18,7 @@ password_kwargs = {
 # find a way to get around it. Note: the slow part is model instantiation, not the
 # database insertion.
 30.times do |i|
-  email = "test" + (i * 3).to_s + "@test.com"
+  email = Faker::Internet.email
   password = Faker::Internet.password(**password_kwargs)
   User.find_or_initialize_by(email: email).update!(
     first_name: Faker::Name.first_name,


### PR DESCRIPTION
Previously, we ran into an issue trying to add emails ending in ".example" since we limited TLDs to 6 characters. This ups it to 63 characters, as that is the actual maximum. See the [mdn web docs](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_domain_name).