### PR TITLE
refactor: use require_seller in ProductsController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,4 +56,15 @@ class ApplicationController < ActionController::Base
       redirect_to login_path
     end
   end
+
+  # Redirects to the root path if the current user is not a seller.
+  # An :alert flash is set before redirecting, using the translation for
+  # the requested controller and action under the :require_seller scope.
+  # See #i18n_t.
+  def require_seller
+    unless Current.user&.is_seller || Current.user&.is_admin
+      flash[:alert] = i18n_t scope: :require_seller
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 class ProductsController < ApplicationController
   before_action :require_login, except: [:show, :index]
+  before_action :require_seller, only: [:new, :create]
 
   def index
     @products = Product.joins(:categories).only_public.in_stock
@@ -44,18 +45,10 @@ class ProductsController < ApplicationController
   end
 
   def new
-    unless Current.user.is_seller
-      flash[:alert] = "You must be a seller to create a product."
-      redirect_to root_path and return
-    end
     @product = Product.new
   end
 
   def create
-    unless Current.user.is_seller
-      flash[:alert] = "You must be a seller to create a product."
-      redirect_to root_path and return
-    end
     @product = Product.new(product_params)
     @product.seller = Current.user
     if @product.save

--- a/app/controllers/storefronts_controller.rb
+++ b/app/controllers/storefronts_controller.rb
@@ -68,13 +68,4 @@ class StorefrontsController < ApplicationController
       end
     end
   end
-
-  private
-
-  def require_seller
-    unless Current.user.is_seller || Current.user.is_admin
-      flash[:alert] = i18n_t scope: :require_seller
-      redirect_to root_path
-    end
-  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,9 @@ en:
     default: "You must be a seller to access that page."
     storefronts:
       default: "You must be a seller to create a storefront"
+    products:
+      default: "You must be a seller to %{action} a product!"
+      new: "You must be a seller to create a product."
   storefronts:
     update:
       success: "Storefront successfully updated!"


### PR DESCRIPTION
This is a simple pull request. All it does is move `require_seller` to `ApplicationController` and makes `ProductsController` use it.