### PR TITLE
Require profiles for sellers

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -146,3 +146,7 @@ label.required:after {
     content:" *";
     color: red;
 }
+
+.future-link {
+    text-decoration: line-through color-mix(in srgb, currentColor 30%, transparent)
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -141,3 +141,8 @@
 .pre-wrap {
     white-space: pre-wrap;
 }
+
+label.required:after {
+    content:" *";
+    color: red;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -148,5 +148,5 @@ label.required:after {
 }
 
 .future-link {
-    text-decoration: line-through color-mix(in srgb, currentColor 30%, transparent)
+    text-decoration: line-through;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,4 +67,15 @@ class ApplicationController < ActionController::Base
       redirect_to root_path
     end
   end
+
+  # Redirects to the root path if the current user is a seller.
+  # An :alert flash is set before redirecting, using the translation for
+  # the requested controller and action under the :require_not_seller scope.
+  # See #i18n_t.
+  def require_not_seller
+    if Current.user&.is_seller
+      flash[:alert] = i18n_t scope: :require_not_seller
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -35,6 +35,7 @@ class ProfilesController < ApplicationController
       flash[:alert] = "You already have a profile!"
       redirect_to profile_path(Current.user.profile)
     end
+    @profile = Profile.new
   end
 
   def create

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -46,8 +46,11 @@ class ProfilesController < ApplicationController
       flash[:notice] = "Profile created successfully!"
       redirect_to profile_path(@profile)
     else
+      # Need to set user to nil because otherwise the navbar/_user_dropdown partial
+      # sees the profile and tries to render a link to it, but profile.id is nil.
+      @profile.user = nil
       flash.now[:alert] = "Profile creation failed. Please check the form."
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -26,7 +26,7 @@ class ProfilesController < ApplicationController
       redirect_to @profile, notice: "Profile was successfully updated."
     else
       flash.now[:alert] = "Profile update failed. Please check the form."
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :require_login, except: [:show]
+  before_action :require_not_seller, only: [:destroy, :delete]
 
   def edit
     @profile = Current.user.profile

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,17 +39,4 @@ class UsersController < ApplicationController
     flash[:notice] = "Registration successful"
     redirect_to root_path
   end
-
-  private
-
-  # Redirects to the root path if the user is a seller.
-  # An :alert flash is set before redirecting, using the translation for
-  # the requested controller and action under the :require_not_seller scope.
-  # See #i18n_t.
-  def require_not_seller
-    if Current.user.is_seller
-      flash[:alert] = i18n_t scope: :require_not_seller
-      redirect_to root_path
-    end
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-
   before_action :require_login, only: [:register, :new_seller]
   before_action :require_not_seller, only: [:register, :new_seller]
 
@@ -36,6 +35,11 @@ class UsersController < ApplicationController
   end
 
   def new_seller
+    if Current.user.profile.nil?
+      Current.user.create_profile public_profile: true
+    else
+      Current.user.profile.update_attribute(:public_profile, true)
+    end
     Current.user.update_attribute(:is_seller, true)
     flash[:notice] = "Registration successful"
     redirect_to root_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,11 +35,6 @@ class UsersController < ApplicationController
   end
 
   def new_seller
-    if Current.user.profile.nil?
-      Current.user.create_profile public_profile: true
-    else
-      Current.user.profile.update_attribute(:public_profile, true)
-    end
     Current.user.update_attribute(:is_seller, true)
     flash[:notice] = "Registration successful"
     redirect_to root_path

--- a/app/helpers/future_link_helper.rb
+++ b/app/helpers/future_link_helper.rb
@@ -1,0 +1,7 @@
+module FutureLinkHelper
+  def future_link_to(name, **options, &block)
+    options[:class] = class_names "future-link", options[:class]
+    options[:title] = "This page doesn't yet exist but will in the future."
+    link_to name, "javascript:;", **options, &block
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -2,12 +2,31 @@ class Profile < ApplicationRecord
   belongs_to :user
   mount_uploader :avatar, AvatarUploader
 
+  # If public_profile was set to false, make sure it's kept to true for sellers.
+  before_validation :set_public_if_seller,
+    if: [:user, :public_profile_changed?],
+    unless: :public_profile
+
   validates :website, format: {with: URI::DEFAULT_PARSER.make_regexp, message: "is not a valid URL"}, allow_blank: true
   validates :twitter, format: {with: %r{\A(?:https?://)?(?:www\.)?x\.com/.*?\z}, message: "is not a valid Twitter link"}, allow_blank: true
   validates :facebook, format: {with: %r{\A(?:https?://)?(?:www\.)?facebook\.com/.*?\z}, message: "is not a valid Facebook link"}, allow_blank: true
   validates :instagram, format: {with: %r{\A(?:https?://)?(?:www\.)?instagram\.com/.*?\z}, message: "is not a valid Instagram link"}, allow_blank: true
+  # validate (singular!) is used for custom validations
+  validate :sellers_have_public_profiles
 
   def full_name
     "#{first_name} #{last_name}"
+  end
+
+  private
+
+  def set_public_if_seller
+    self.public_profile = user.is_seller
+  end
+
+  def sellers_have_public_profiles
+    if user&.is_seller && !public_profile
+      errors.add(:public_profile, "must be true for sellers")
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,12 @@ class User < ApplicationRecord
   has_secure_password
   before_save { |user| user.email = user.email.downcase }
   before_save :create_session_token
+  # If a user's is_seller attribute is changed to true, make sure they have a profile.
+  # This has to be after a commit because (for new users) we need to save the user
+  # before we can create a profile for them.
+  after_save_commit :update_profile_visibility,
+    if: [:saved_change_to_is_seller?, :is_seller?]
+
   validates :first_name, presence: true, length: {maximum: 50}
   validates :last_name, presence: true, length: {maximum: 50}
   VALID_EMAIL_REGEX = /\A(|(([A-Za-z0-9]+_+)|([A-Za-z0-9]+-+)|([A-Za-z0-9]+\.+)|([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+-+)|(\w+\.))*\w{1,63}\.[a-zA-Z]{2,24})\z/i
@@ -61,5 +67,12 @@ class User < ApplicationRecord
 
   def create_session_token
     self.session_token = SecureRandom.urlsafe_base64
+  end
+
+  def update_profile_visibility
+    if is_seller? && (profile.nil? || !profile.public_profile)
+      build_profile(public_profile: true) unless profile
+      profile.update(public_profile: true)
+    end
   end
 end

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -4,7 +4,7 @@ along with some modifications
 %>
 <header class="navbar navbar-expand-md navbar-dark bg-dark sticky-top">
   <nav class="container-xl flex-wrap flex-md-nowrap" aria-label="Navigation">
-    <a class="navbar-brand" href="#">Shoppr</a>
+    <%= link_to "Shoppr", root_path, class: "navbar-brand" %>
     <button class="navbar-toggler"
             type="button"
             data-bs-toggle="collapse"

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -33,7 +33,10 @@
         <%= f.select(
               :public_profile,
               [["Public", true], ["Private", false]],
-              label: "Profile Visibility:"
+              {label: "Profile Visibility:"}, # select options
+              profile.user&.is_seller ? # html options
+                {disabled: true, title: "Sellers must have public profiles."} :
+                {}
             ) %>
 
         <%= link_to "Cancel", :back, class: "btn btn-secondary" %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -12,10 +12,10 @@
   <%= f.text_field :last_name, label: "Last Name:" %>
   <%= f.text_area :bio, label: "Bio:" %>
   <%= f.text_field :location, label: "Location:" %>
-  <%= f.text_field :twitter, label: "Twitter:" %>
-  <%= f.text_field :facebook, label: "Facebook:" %>
-  <%= f.text_field :instagram, label: "Instagram:" %>
-  <%= f.text_field :website, label: "Website:" %>
+  <%= f.url_field :twitter, label: "Twitter:" %>
+  <%= f.url_field :facebook, label: "Facebook:" %>
+  <%= f.url_field :instagram, label: "Instagram:" %>
+  <%= f.url_field :website, label: "Website:" %>
   <%= f.text_field :occupation, label: "Occupation:" %>
   <%= f.select(
         :public_profile,

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -13,8 +13,14 @@
           </div>
         <% end %>
 
-        <%= f.text_field :first_name, label: "First Name:" %>
-        <%= f.text_field :last_name, label: "Last Name:" %>
+        <div class="row">
+          <div class="col-md-6">
+            <%= f.text_field :first_name, label: "First Name:" %>
+          </div>
+          <div class="col-md-6">
+            <%= f.text_field :last_name, label: "Last Name:" %>
+          </div>
+        </div>
         <%= f.text_area :bio, label: "Bio:", rows: 5 %>
         <%= f.text_field :location, label: "Location:" %>
         <%= f.text_field :occupation, label: "Occupation:" %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,4 +1,4 @@
-<%= bootstrap_form_with model: profile, html: {autocomplete: false} do |f| %>
+<%= bootstrap_form_with model: profile, html: {autocomplete: "off"} do |f| %>
   <%= f.file_field :avatar, label: "Profile Picture:" %>
   <% if profile.avatar.file.present? %>
     <div class="mb-3">

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -22,5 +22,6 @@
         [["Public", true], ["Private", false]],
         label: "Profile Visibility:"
       ) %>
+  <%= link_to "Cancel", :back, class: "btn btn-secondary" %>
   <%= f.primary %>
 <% end %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,31 +1,38 @@
-<%= bootstrap_form_with model: profile, html: {autocomplete: "off"} do |f| %>
-  <%= f.file_field :avatar, label: "Profile Picture:" %>
-  <% if profile.avatar.file.present? %>
-    <div class="mb-3">
-      <%# "form-label" is inaccurate since this isn't actually an input, but
-          we use it so that the page stays consistent. %>
-      <p class="form-label">Current Profile Picture:</p>
-      <%= image_tag profile.avatar.url, class: "img-thumbnail", alt: "Current Avatar" %>
+<div class="row d-flex justify-content-center align-items-center">
+  <div class="col-sm-12 col-md-10 col-lg-8">
+    <div class="card p-5">
+      <h1 class="text-center mb-3"><%= local_assigns[:header] || "Profile" %></h1>
+      <%= bootstrap_form_with model: profile, html: {autocomplete: "off"} do |f| %>
+        <%= f.file_field :avatar, label: "Profile Picture:" %>
+        <% if profile.avatar.file.present? %>
+          <div class="mb-3">
+            <%# "form-label" is inaccurate since this isn't actually an input, but
+                we use it so that the page stays consistent. %>
+            <p class="form-label">Current Profile Picture:</p>
+            <%= image_tag profile.avatar.url, class: "img-thumbnail", alt: "Current Avatar" %>
+          </div>
+        <% end %>
+
+        <%= f.text_field :first_name, label: "First Name:" %>
+        <%= f.text_field :last_name, label: "Last Name:" %>
+        <%= f.text_area :bio, label: "Bio:", rows: 5 %>
+        <%= f.text_field :location, label: "Location:" %>
+        <%= f.text_field :occupation, label: "Occupation:" %>
+
+        <%= f.url_field :twitter, label: "Twitter:" %>
+        <%= f.url_field :facebook, label: "Facebook:" %>
+        <%= f.url_field :instagram, label: "Instagram:" %>
+        <%= f.url_field :website, label: "Website:" %>
+
+        <%= f.select(
+              :public_profile,
+              [["Public", true], ["Private", false]],
+              label: "Profile Visibility:"
+            ) %>
+
+        <%= link_to "Cancel", :back, class: "btn btn-secondary" %>
+        <%= f.primary %>
+      <% end %>
     </div>
-  <% end %>
-
-  <%= f.text_field :first_name, label: "First Name:" %>
-  <%= f.text_field :last_name, label: "Last Name:" %>
-  <%= f.text_area :bio, label: "Bio:" %>
-  <%= f.text_field :location, label: "Location:" %>
-  <%= f.text_field :occupation, label: "Occupation:" %>
-
-  <%= f.url_field :twitter, label: "Twitter:" %>
-  <%= f.url_field :facebook, label: "Facebook:" %>
-  <%= f.url_field :instagram, label: "Instagram:" %>
-  <%= f.url_field :website, label: "Website:" %>
-
-  <%= f.select(
-        :public_profile,
-        [["Public", true], ["Private", false]],
-        label: "Profile Visibility:"
-      ) %>
-
-  <%= link_to "Cancel", :back, class: "btn btn-secondary" %>
-  <%= f.primary %>
-<% end %>
+  </div>
+</div>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,0 +1,26 @@
+<%= bootstrap_form_with model: profile, html: {autocomplete: false} do |f| %>
+  <%= f.file_field :avatar, label: "Profile Picture:" %>
+  <% if profile.avatar.file.present? %>
+    <div class="mb-3">
+      <%# "form-label" is inaccurate since this isn't actually an input, but
+          we use it so that the page stays consistent. %>
+      <p class="form-label">Current Profile Picture:</p>
+      <%= image_tag profile.avatar.url, class: "img-thumbnail", alt: "Current Avatar" %>
+    </div>
+  <% end %>
+  <%= f.text_field :first_name, label: "First Name:" %>
+  <%= f.text_field :last_name, label: "Last Name:" %>
+  <%= f.text_area :bio, label: "Bio:" %>
+  <%= f.text_field :location, label: "Location:" %>
+  <%= f.text_field :twitter, label: "Twitter:" %>
+  <%= f.text_field :facebook, label: "Facebook:" %>
+  <%= f.text_field :instagram, label: "Instagram:" %>
+  <%= f.text_field :website, label: "Website:" %>
+  <%= f.text_field :occupation, label: "Occupation:" %>
+  <%= f.select(
+        :public_profile,
+        [["Public", true], ["Private", false]],
+        label: "Profile Visibility:"
+      ) %>
+  <%= f.primary %>
+<% end %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -8,20 +8,24 @@
       <%= image_tag profile.avatar.url, class: "img-thumbnail", alt: "Current Avatar" %>
     </div>
   <% end %>
+
   <%= f.text_field :first_name, label: "First Name:" %>
   <%= f.text_field :last_name, label: "Last Name:" %>
   <%= f.text_area :bio, label: "Bio:" %>
   <%= f.text_field :location, label: "Location:" %>
+  <%= f.text_field :occupation, label: "Occupation:" %>
+
   <%= f.url_field :twitter, label: "Twitter:" %>
   <%= f.url_field :facebook, label: "Facebook:" %>
   <%= f.url_field :instagram, label: "Instagram:" %>
   <%= f.url_field :website, label: "Website:" %>
-  <%= f.text_field :occupation, label: "Occupation:" %>
+
   <%= f.select(
         :public_profile,
         [["Public", true], ["Private", false]],
         label: "Profile Visibility:"
       ) %>
+
   <%= link_to "Cancel", :back, class: "btn btn-secondary" %>
   <%= f.primary %>
 <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -9,15 +9,15 @@
       <%= image_tag @profile.avatar.url, class: 'img-thumbnail', alt: 'Current Avatar' %>
     </div>
   <% end %>
-  <%= f.text_field :first_name, label: "First Name:", value: @profile.first_name %>
-  <%= f.text_field :last_name, label: "Last Name:", value: @profile.last_name %>
-  <%= f.text_area :bio, label: "Bio:", value: @profile.bio %>
-  <%= f.text_field :location, label: "Location:", value: @profile.location %>
-  <%= f.text_field :twitter, label: "Twitter:", value: @profile.twitter %>
-  <%= f.text_field :facebook, label: "Facebook:", value: @profile.facebook %>
-  <%= f.text_field :instagram, label: "Instagram:", value: @profile.instagram %>
-  <%= f.text_field :website, label: "Website:", value: @profile.website %>
-  <%= f.text_field :occupation, label: "Occupation:", value: @profile.occupation %>
+  <%= f.text_field :first_name, label: "First Name:" %>
+  <%= f.text_field :last_name, label: "Last Name:" %>
+  <%= f.text_area :bio, label: "Bio:" %>
+  <%= f.text_field :location, label: "Location:" %>
+  <%= f.text_field :twitter, label: "Twitter:" %>
+  <%= f.text_field :facebook, label: "Facebook:" %>
+  <%= f.text_field :instagram, label: "Instagram:" %>
+  <%= f.text_field :website, label: "Website:" %>
+  <%= f.text_field :occupation, label: "Occupation:" %>
   <%= f.select :public_profile, options_for_select([['Public', true], ['Private', false]]), label: "Profile Visibility:", selected: @profile.public_profile %>
   <%= f.submit "Submit Updates", class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -6,7 +6,7 @@
       <%# "form-label" is inaccurate since this isn't actually an input, but
           we use it so that the page stays consistent. %>
       <p class="form-label">Current Profile Picture:</p>
-      <%= image_tag @profile.avatar.url, class: 'img-thumbnail', alt: 'Current Avatar' %>
+      <%= image_tag @profile.avatar.url, class: "img-thumbnail", alt: "Current Avatar" %>
     </div>
   <% end %>
   <%= f.text_field :first_name, label: "First Name:" %>
@@ -20,7 +20,7 @@
   <%= f.text_field :occupation, label: "Occupation:" %>
   <%= f.select(
         :public_profile,
-        [['Public', true], ['Private', false]],
+        [["Public", true], ["Private", false]],
         label: "Profile Visibility:"
       ) %>
   <%= f.primary %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,5 +1,5 @@
 <p>Edit whatever info you'd like</p>
-<%= bootstrap_form_with(model: @profile, url: profile_path(@profile), method: :patch, local: true) do |f| %>
+<%= bootstrap_form_with model: @profile do |f| %>
   <%= f.file_field :avatar, label: "Profile Picture:" %>
   <% if @profile.avatar.file.present? %>
     <div class="mb-3">

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,7 +1,6 @@
+<p>Edit whatever info you'd like</p>
 <%= bootstrap_form_with(model: @profile, url: profile_path(@profile), method: :patch, local: true) do |f| %>
-  <%= f.label "Edit whatever info you'd like" %>
-  <%#= f.label :avatar, "Profile Picture:" %>
-  <%= f.file_field :avatar %>
+  <%= f.file_field :avatar, label: "Profile Picture:" %>
   <%= f.label :old_avatar, "Current Profile Picture:" %>
   <% if @profile.avatar.file.present? %>
     <%= image_tag @profile.avatar.url, class: 'img-thumbnail', alt: 'Current Avatar' %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -18,6 +18,10 @@
   <%= f.text_field :instagram, label: "Instagram:" %>
   <%= f.text_field :website, label: "Website:" %>
   <%= f.text_field :occupation, label: "Occupation:" %>
-  <%= f.select :public_profile, options_for_select([['Public', true], ['Private', false]]), label: "Profile Visibility:", selected: @profile.public_profile %>
+  <%= f.select(
+        :public_profile,
+        [['Public', true], ['Private', false]],
+        label: "Profile Visibility:"
+      ) %>
   <%= f.primary %>
 <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,2 +1,1 @@
-<p>Edit whatever info you'd like</p>
-<%= render "form", profile: @profile %>
+<%= render "form", profile: @profile, header: "Edit Profile" %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,9 +1,13 @@
 <p>Edit whatever info you'd like</p>
 <%= bootstrap_form_with(model: @profile, url: profile_path(@profile), method: :patch, local: true) do |f| %>
   <%= f.file_field :avatar, label: "Profile Picture:" %>
-  <%= f.label :old_avatar, "Current Profile Picture:" %>
   <% if @profile.avatar.file.present? %>
-    <%= image_tag @profile.avatar.url, class: 'img-thumbnail', alt: 'Current Avatar' %>
+    <div class="mb-3">
+      <%# "form-label" is inaccurate since this isn't actually an input, but
+          we use it so that the page stays consistent. %>
+      <p class="form-label">Current Profile Picture:</p>
+      <%= image_tag @profile.avatar.url, class: 'img-thumbnail', alt: 'Current Avatar' %>
+    </div>
   <% end %>
   <%= f.text_field :first_name, label: "First Name:", value: @profile.first_name %>
   <%= f.text_field :last_name, label: "Last Name:", value: @profile.last_name %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -19,5 +19,5 @@
   <%= f.text_field :website, label: "Website:" %>
   <%= f.text_field :occupation, label: "Occupation:" %>
   <%= f.select :public_profile, options_for_select([['Public', true], ['Private', false]]), label: "Profile Visibility:", selected: @profile.public_profile %>
-  <%= f.submit "Submit Updates", class: 'btn btn-primary' %>
+  <%= f.primary %>
 <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,27 +1,2 @@
 <p>Edit whatever info you'd like</p>
-<%= bootstrap_form_with model: @profile do |f| %>
-  <%= f.file_field :avatar, label: "Profile Picture:" %>
-  <% if @profile.avatar.file.present? %>
-    <div class="mb-3">
-      <%# "form-label" is inaccurate since this isn't actually an input, but
-          we use it so that the page stays consistent. %>
-      <p class="form-label">Current Profile Picture:</p>
-      <%= image_tag @profile.avatar.url, class: "img-thumbnail", alt: "Current Avatar" %>
-    </div>
-  <% end %>
-  <%= f.text_field :first_name, label: "First Name:" %>
-  <%= f.text_field :last_name, label: "Last Name:" %>
-  <%= f.text_area :bio, label: "Bio:" %>
-  <%= f.text_field :location, label: "Location:" %>
-  <%= f.text_field :twitter, label: "Twitter:" %>
-  <%= f.text_field :facebook, label: "Facebook:" %>
-  <%= f.text_field :instagram, label: "Instagram:" %>
-  <%= f.text_field :website, label: "Website:" %>
-  <%= f.text_field :occupation, label: "Occupation:" %>
-  <%= f.select(
-        :public_profile,
-        [["Public", true], ["Private", false]],
-        label: "Profile Visibility:"
-      ) %>
-  <%= f.primary %>
-<% end %>
+<%= render "form", profile: @profile %>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -11,5 +11,5 @@
   <%= f.text_field :website, label: "Website:" %>
   <%= f.text_field :occupation, label: "Occupation:" %>
   <%= f.select :public_profile, options_for_select([['Public', true], ['Private', false]]), label: "Profile Visibility:" %>
-  <%= f.submit "Create Profile", class: 'btn btn-primary' %>
+  <%= f.primary "Create Profile" %>
 <% end %>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,2 +1,1 @@
-<p>Add whatever info you'd like</p>
-<%= render "form", profile: @profile %>
+<%= render "form", profile: @profile, header: "New Profile" %>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,15 +1,2 @@
 <p>Add whatever info you'd like</p>
-<%= bootstrap_form_with model: @profile do |f| %>
-  <%= f.file_field :avatar, label: "Profile Picture:" %>
-  <%= f.text_field :first_name, label: "First Name:" %>
-  <%= f.text_field :last_name, label: "Last Name:" %>
-  <%= f.text_area :bio, label: "Bio:" %>
-  <%= f.text_field :location, label: "Location:" %>
-  <%= f.text_field :twitter, label: "Twitter:" %>
-  <%= f.text_field :facebook, label: "Facebook:" %>
-  <%= f.text_field :instagram, label: "Instagram:" %>
-  <%= f.text_field :website, label: "Website:" %>
-  <%= f.text_field :occupation, label: "Occupation:" %>
-  <%= f.select :public_profile, options_for_select([['Public', true], ['Private', false]]), label: "Profile Visibility:" %>
-  <%= f.primary "Create Profile" %>
-<% end %>
+<%= render "form", profile: @profile %>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,5 +1,5 @@
 <p>Add whatever info you'd like</p>
-<%= bootstrap_form_with(model: @profile, url: profiles_path, scope: :profile, method: :post, local: true) do |f| %>
+<%= bootstrap_form_with model: @profile do |f| %>
   <%= f.file_field :avatar, label: "Profile Picture:" %>
   <%= f.text_field :first_name, label: "First Name:" %>
   <%= f.text_field :last_name, label: "Last Name:" %>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,7 +1,6 @@
+<p>Add whatever info you'd like</p>
 <%= bootstrap_form_with(model: @profile, url: profiles_path, scope: :profile, method: :post, local: true) do |f| %>
-  <%= f.label "Add whatever info you'd like" %>
-  <%= f.label :avatar, "Profile Picture:" %>
-  <%= f.file_field :avatar %>
+  <%= f.file_field :avatar, label: "Profile Picture:" %>
   <%= f.text_field :first_name, label: "First Name:" %>
   <%= f.text_field :last_name, label: "Last Name:" %>
   <%= f.text_area :bio, label: "Bio:" %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -31,7 +31,19 @@
   <!-- Links -->
   <% if @is_current_user %>
     <%= link_to "Edit Profile", edit_profile_path(@profile), method: :get, class: "btn btn-primary" %>
-    <%= link_to "Delete Profile", delete_profile_path(@profile), method: :get, class: "btn btn-danger" %>
+    <% if Current.user.is_seller %>
+      <%# Have to wrap in span since .disabled adds `pointer-events: none` which
+          prevents the title appearing on hover. The `d-inline-block` class is
+          added so that the span takes up the same space as the link. %>
+      <span class="d-inline-block" title="Sellers cannot delete their profiles.">
+        <%# https://getbootstrap.com/docs/5.3/components/buttons/#disabled-state %>
+        <a class="btn btn-danger disabled" role="button" aria-disabled="true">
+          Delete Profile
+        </a>
+      </span>
+    <% else %>
+      <%= link_to "Delete Profile", delete_profile_path(@profile), method: :get, class: "btn btn-danger" %>
+    <% end %>
   <% end %>
   <% if @show_review_link %>
     <%= link_to "Leave A Review", review_path(profile_id: @profile), method: :get, class: "btn btn-secondary" %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -30,7 +30,7 @@
 
   <!-- Links -->
   <% if @is_current_user %>
-    <%= link_to "Edit Profile", edit_profile_path(@profile), method: :get, class: "btn btn-danger" %>
+    <%= link_to "Edit Profile", edit_profile_path(@profile), method: :get, class: "btn btn-primary" %>
     <%= link_to "Delete Profile", delete_profile_path(@profile), method: :get, class: "btn btn-danger" %>
   <% end %>
   <% if @show_review_link %>

--- a/app/views/users/register.html.erb
+++ b/app/views/users/register.html.erb
@@ -27,12 +27,12 @@
         <%= f.check_box(
               :understand_above,
               required: true,
-              label: "I understand the above"
+              label: "I understand the above and wish to register"
             ) %>
         <%= f.check_box(
               :agree_tos,
               required: true,
-              label: "I agree to the #{
+              label: "I have read and agree to the #{
                   future_link_to "terms and conditions"
                 }".html_safe
             ) %>

--- a/app/views/users/register.html.erb
+++ b/app/views/users/register.html.erb
@@ -4,7 +4,7 @@
       <h2 class="text-center mb-3">Register to sell</h2>
       <p>
         To sell items on the marketplace, you must fill out the form below.
-        Note that sellers are
+        Sellers are
         <span class="fw-bold">required</span>
         to have a public profile:
       </p>

--- a/app/views/users/register.html.erb
+++ b/app/views/users/register.html.erb
@@ -1,8 +1,45 @@
-<%= bootstrap_form_with model: @user, url: register_path, title: "Register to sell", method: :post, local: true do |f| %>
-  <%= f.text_field :storefront, label: "Storefront name: " %>
-  <%= f.text_field :email, label: "Business email (Optional): ", help: " (Leaving this field blank will default
-   to your account email)" %>
-  <%= f.check_box :info, label: "I want to make my name and email address visible to other users" %>
-  <%= f.check_box :agree, label: "I agree to the terms and conditions. (Required)" %>
-  <%= f.submit "Submit" %>
-<% end %>
+<div class="row d-flex justify-content-center align-items-center">
+  <div class="col-sm-12 col-md-10 col-lg-8">
+    <div class="card p-5">
+      <h2 class="text-center mb-3">Register to sell</h2>
+      <p>
+        To sell items on the marketplace, you must fill out the form below.
+        Note that sellers are
+        <span class="fw-bold">required</span>
+        to have a public profile:
+      </p>
+      <ul>
+        <li>
+          If you don't have a profile, a public one will be created for you
+          automatically.
+        </li>
+        <li>
+          If you do have one, it will be made public if it isn't already.
+        </li>
+      </ul>
+      <p class="mb-5">
+        Once you register, your profile cannot be made private. Along with this,
+        <strong class="text-danger">
+          you will not be able to delete your account.
+        </strong>
+      </p>
+      <%= bootstrap_form_with model: @user, url: register_path do |f| %>
+        <%= f.check_box(
+              :understand_above,
+              required: true,
+              label: "I understand the above"
+            ) %>
+        <%= f.check_box(
+              :agree_tos,
+              required: true,
+              label: "I agree to the #{
+                  future_link_to "terms and conditions"
+                }".html_safe
+            ) %>
+        <div class="d-flex justify-content-center mt-4">
+          <%= f.submit "Register", extra_class: "w-25" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,9 @@ en:
     users:
       register: "You already are a seller, no need to register again!"
       new_seller: "You already are a seller, no need to register again!"
+    profiles:
+      destroy: "Sellers cannot delete their profiles!"
+      delete: "Sellers cannot delete their profiles!"
   require_seller:
     default: "You must be a seller to access that page."
     storefronts:

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -281,6 +281,13 @@ describe ProfilesController, type: :controller do
       expect(response).to redirect_to(root_path)
       expect(flash[:alert]).to eq("You don't have a profile to delete!")
     end
+
+    it "redirects to the root path with an alert for a seller" do
+      valid_user.update(is_seller: true)
+      delete :destroy, params: {id: valid_user.profile.id}
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq("Sellers cannot delete their profiles!")
+    end
   end
 
   # delete
@@ -290,6 +297,13 @@ describe ProfilesController, type: :controller do
       session[:user_id] = other_user.id
       get :delete, params: {id: other_user.profile.id}
       expect(response).to render_template("delete")
+    end
+
+    it "redirects to the root path with an alert for a seller" do
+      user = login_as create(:user_with_profile, is_seller: true)
+      get :delete, params: {id: user.profile.id}
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq("Sellers cannot delete their profiles!")
     end
   end
   # Other tests can be added

--- a/spec/controllers/reviews_controller_spec.rb
+++ b/spec/controllers/reviews_controller_spec.rb
@@ -35,7 +35,7 @@ describe ReviewsController, type: :controller do
 
   describe "create" do
     let(:seller) { create(:user, is_seller: true) }
-    let(:seller_profile) { create(:profile, user: seller) }
+    let(:seller_profile) { create(:profile, user: seller, public_profile: true) }
     let(:valid_attributes) do
       {
         seller_id: seller.id,

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe UsersController, type: :controller do
       it "does not creates a new user" do
         expect {
           post :create, params: {user: invalid_user}
-        }.to change(User, :count).by(0)
+        }.to_not change(User, :count)
         expect(response).to render_template(:new)
         expect(flash[:alert]).to eq("Invalid input(s)!")
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -75,11 +75,21 @@ RSpec.describe UsersController, type: :controller do
     end
 
     context "with a valid non-seller logged in" do
+      let(:user) { login_as create(:user) }
+
       it "makes the user a seller" do
-        user = create(:user)
-        login_as user
         expect { post :new_seller }.to change { user.reload.is_seller }.to(true)
         expect(flash[:notice]).to eq("Registration successful")
+      end
+
+      it "creates a public profile for the user" do
+        expect { post :new_seller }.to change { user.reload.profile }.from(nil)
+        expect(user.profile.public_profile).to eq(true)
+      end
+
+      it "makes the user's profile public if it already exists" do
+        profile = user.create_profile public_profile: false
+        expect { post :new_seller }.to change { profile.reload.public_profile }.to(true)
       end
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,31 +1,11 @@
 require "rails_helper"
 
 RSpec.describe UsersController, type: :controller do
-  let(:valid_user) do
-    {
-      first_name: "John",
-      last_name: "Doe",
-      email: "john.doe@example.com",
-      password: "password123!P",
-      password_confirmation: "password123!P"
-    }
-  end
-
-  let(:invalid_user) do
-    {
-      first_name: "John",
-      last_name: "Doe",
-      email: "john.doeexample.com",
-      password: "pass",
-      password_confirmation: "password123"
-    }
-  end
-
   describe "POST #create" do
     context "with valid attributes" do
       it "creates a new user and redirects" do
         expect {
-          post :create, params: {user: valid_user}
+          post :create, params: {user: attributes_for(:user)}
         }.to change(User, :count).by(1)
         expect(response).to redirect_to(login_path)
         expect(flash[:notice]).to eq("Sign up successful!")
@@ -35,7 +15,7 @@ RSpec.describe UsersController, type: :controller do
     context "with invalid attributes" do
       it "does not creates a new user" do
         expect {
-          post :create, params: {user: invalid_user}
+          post :create, params: {user: attributes_for(:user, password: "pass")}
         }.to_not change(User, :count)
         expect(response).to render_template(:new)
         expect(flash[:alert]).to eq("Invalid input(s)!")

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -75,21 +75,10 @@ RSpec.describe UsersController, type: :controller do
     end
 
     context "with a valid non-seller logged in" do
-      let(:user) { login_as create(:user) }
-
       it "makes the user a seller" do
+        user = login_as create(:user)
         expect { post :new_seller }.to change { user.reload.is_seller }.to(true)
         expect(flash[:notice]).to eq("Registration successful")
-      end
-
-      it "creates a public profile for the user" do
-        expect { post :new_seller }.to change { user.reload.profile }.from(nil)
-        expect(user.profile.public_profile).to eq(true)
-      end
-
-      it "makes the user's profile public if it already exists" do
-        profile = user.create_profile public_profile: false
-        expect { post :new_seller }.to change { profile.reload.public_profile }.to(true)
       end
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -75,10 +75,10 @@ RSpec.describe UsersController, type: :controller do
     end
 
     context "with a valid non-seller logged in" do
-      it "retrieves a logged-in user's information from the database" do
+      it "makes the user a seller" do
         user = create(:user)
         login_as user
-        post :new_seller
+        expect { post :new_seller }.to change { user.reload.is_seller }.to(true)
         expect(flash[:notice]).to eq("Registration successful")
       end
     end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,12 +1,46 @@
 require "rails_helper"
 
 RSpec.describe Profile, type: :model do
-  let(:valid_user) { create(:user, email: "testtests@admin.com", password: "admin1000!P", password_confirmation: "admin1000!P") }
+  let(:user) { create(:user) }
+  let(:seller) { create(:seller) }
 
   # full name is first_name plus last name
   it "has a full name" do
     profile = Profile.new(first_name: "John", last_name: "Doe")
-    profile.user = valid_user
+    profile.user = user
     expect(profile.full_name).to eq("John Doe")
+  end
+
+  # describe "validations" do
+  #   # This test doesn't work because the set_public_if_seller method is called
+  #   # before validation, so the public_profile attribute is always true. We shouldn't
+  #   # even need the validation, but I added it just in case. However, I'm not sure how
+  #   # I could even test it.
+  #   # it "must be public for sellers" do
+  #   #   profile = Profile.new(public_profile: false)
+  #   #   profile.user = seller
+  #   #   expect(profile).to_not be_valid
+  #   # end
+  # end
+
+  describe "set_public_if_seller" do
+    it "sets public_profile to true if user is a seller" do
+      profile = seller.create_profile
+      profile.update(public_profile: false)
+      expect(profile.public_profile).to eq(true)
+    end
+
+    it "isn't called when public_profile is set to true" do
+      profile = Profile.new
+      profile.user = seller
+      expect(profile).to_not receive(:set_public_if_seller)
+      profile.update(public_profile: true)
+    end
+
+    it "isn't called when public_profile isn't changed" do
+      profile = seller.create_profile
+      expect(profile).to_not receive(:set_public_if_seller)
+      profile.update(first_name: "John")
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -69,4 +69,34 @@ RSpec.describe User, type: :model do
       expect(user.full_name).to eq("John Doe")
     end
   end
+
+  describe "update_profile_visibility" do
+    it "creates a public profile if user is a seller without a profile" do
+      user = build(:user)
+      expect {
+        # Have to use `update` here since we need to commit for the callback to run
+        user.update(is_seller: true)
+      }.to change { user.profile }.from(nil)
+      expect(user.profile.public_profile).to eq(true)
+    end
+
+    it "sets public_profile to true if user is a seller with a profile" do
+      user = create(:user_with_private_profile)
+      expect {
+        user.update(is_seller: true)
+      }.to change { user.profile.public_profile }.from(false).to(true)
+    end
+
+    it "isn't called if user is not a seller" do
+      user = build(:user)
+      expect(user).to_not receive(:update_profile_visibility)
+      user.save
+    end
+
+    it "isn't called if is_seller is set to false" do
+      user = create(:user)
+      expect(user).to_not receive(:update_profile_visibility)
+      user.update(is_seller: false)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "is_admin=" do
+    it "sets is_seller when is_admin is set to true" do
+      user = build(:user)
+      expect { user.is_admin = true }.to change { user.is_seller }.from(false).to(true)
+    end
+
+    it "sets is_buyer when is_admin is set to true" do
+      user = build(:user)
+      expect { user.is_admin = true }.to change { user.is_buyer }.from(false).to(true)
+    end
+  end
+
   describe "update_profile_visibility" do
     it "creates a public profile if user is a seller without a profile" do
       user = build(:user)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,5 +1,6 @@
 module Helpers
   def login_as(user)
     session[:user_id] = user.id
+    user
   end
 end


### PR DESCRIPTION
This PR implements checks and restrictions ensuring that sellers have public profiles. Specifically:

- Registering as a seller creates a public profile is the user doesn't have one.
- Registering as a seller changes the user's profile to public if they have one.
- Disable the "Profile Visibility:" select in the profile form when the user is a seller.
- If a seller bypasses the select and tries to set `public_profile` to `false`, it is silently switched to true.
- Disables the "Delete Profile" button when the user is a seller.
- If a seller tries to delete their profile anyway, they're redirected to the home page with an alert.

Additionally, the `/register` view has been updated to warn the user about these restrictions on their profile:

![Screenshot 2023-12-07 at 23-49-47 Selt2023FinalProjectTeam001](https://github.com/uiowahjmjohnsonselt2023/selt2023-final-project-team-001/assets/6924485/53919c85-3021-47bb-aef8-49c304805879)

Please let me know if I missed anything!