### PR TITLE
Indicate that footer links don't go anywhere right now

### DIFF
--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -34,7 +34,13 @@ module NavbarHelper
     options[:aria] = {current: "page"}.merge(options[:aria] || {}) if active
     options[:class] = class_names "nav-link", active, disabled, options[:class]
 
-    navbar_item(**li_options) { link_to(*args, **options, &block) }
+    link = if options.delete(:future_link)
+      future_link_to(*args, **options, &block)
+    else
+      link_to(*args, **options, &block)
+    end
+
+    navbar_item(**li_options) { link }
   end
 
   # Creates a navbar dropdown.

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -11,9 +11,9 @@
 
     <ul class="nav justify-content-end">
       <%= footer_link "Home", root_path %>
-      <%= footer_link "Features", "#" %>
-      <%= footer_link "FAQs", "#" %>
-      <%= footer_link "About", "#" %>
+      <%= footer_link "Features", future_link: true %>
+      <%= footer_link "FAQs", future_link: true %>
+      <%= footer_link "About", future_link: true %>
     </ul>
   </div>
 </footer>


### PR DESCRIPTION
This is a simple PR that adds indication to the `Features`, `FAQs`, and `About` links in the footer that they don't link to anywhere right now but will in the future.