### PR TITLE
fix: fix leaving a review

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -4,7 +4,7 @@ class ReviewsController < ApplicationController
     @profile_id = params[:profile_id]
     @profile = Profile.find @profile_id
     @seller_id = @profile.user_id
-    @name = @profile.first_name + " " + @profile.last_name
+    @name = @profile.user.full_name
 
     if Current.user.id == @seller_id.to_i
       flash[:alert] = "You cannot leave a review for yourself."


### PR DESCRIPTION
This line in review_controllers new

@name = @profile.first_name + " " + @profile.last_name

fails when you click create a review this error is thrown, because users don't have to have a first name or last name on their profile. No profile fields are required right now afaik. 

NoMethodError (undefined method `+' for nil:NilClass
    @name = @profile.first_name + " " + @profile.last_name
                                ^):
app/controllers/reviews_controller.rb:7:in `new'
Processing by ErrorsController#internal_server_error as HTML

@name = @profile.user.full_name
is a fix, because users have to have first name and last name and the method full_name concatenates those for us