### PR TITLE
tweak: format date and use price instead of price_cents

### DIFF
--- a/app/views/products/history.html.erb
+++ b/app/views/products/history.html.erb
@@ -21,8 +21,8 @@
           </div>
         </td>
         <td><%= link_to product.name, product_path(product.id) %></td>
-        <td><%= number_to_currency product.price_cents %></td>
-        <td><%= product.created_at %></td>
+        <td><%= number_to_currency product.price %></td>
+        <td><%= product.created_at.strftime("%B %e, %Y %l:%M %p") %></td>
         <td><%= product.views %></td>
       </tr>
     <% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -22,7 +22,7 @@
         </td>
         <td><%= link_to product.name, product_path(product.id) %></td>
         <td><%= number_to_currency product.price %></td>
-        <td><%= product.created_at %></td>
+        <td><%= product.created_at.strftime("%B %e, %Y %l:%M %p") %></td>
         <td><%= product.views %>
       </tr>
     <% end %>


### PR DESCRIPTION
This pr contains code for formatting dates and times. Also fixes a bug where price cents was used instead of price causing price to be multiplied by 100